### PR TITLE
Fix example getPlConceptDefinitionSet()

### DIFF
--- a/R/Phenotypes.R
+++ b/R/Phenotypes.R
@@ -195,7 +195,9 @@ getPhenotypeLog <- function(cohortIds = NULL,
 #' A tibble.
 #'
 #' @examples
-#' getPhenotypeLog(cohortIds = c(1, 2))
+#' cohorts <- getPhenotypeLog()
+#' subsetIds <- cohorts$cohortId[1:3]
+#' getPlConceptDefinitionSet(cohortIds = subsetIds)
 #'
 #' @export
 getPlConceptDefinitionSet <-

--- a/man/getPlConceptDefinitionSet.Rd
+++ b/man/getPlConceptDefinitionSet.Rd
@@ -18,6 +18,8 @@ A tibble.
 Get conceptSets in cohorts
 }
 \examples{
-getPhenotypeLog(cohortIds = c(1, 2))
+cohorts <- getPhenotypeLog()
+subsetIds <- cohorts$cohortId[1:3]
+getPlConceptDefinitionSet(cohortIds = subsetIds)
 
 }


### PR DESCRIPTION
Hi @gowthamrao I think the example of `getPlConceptDefinitionSet()` uses `getPhenotypeLog()` instead. Here a PR to fix the example if useful.